### PR TITLE
Support structured args on manual addCommand method

### DIFF
--- a/src/Commands/GraphicField.php
+++ b/src/Commands/GraphicField.php
@@ -81,9 +81,14 @@ class GraphicField
         if ($im === false) {
             throw new Exception('Image not supported');
         }
-
-        $aux = imagescale($im, $width);
-        $height = imagesy($aux);
+        if ($width <= 0) {
+            $width = imagesx($im);
+            $height = imagesy($im);
+        } else {
+            $aux = imagescale($im, $width);
+            $height = imagesy($aux);
+            imagedestroy($aux);
+        }
 
         $originalWidth = imagesx($im);
         $originalHeight = imagesy($im);

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -249,13 +249,31 @@ class ZplBuilder extends AbstractBuilder
     }
 
     /**
+     *
+     * @param array $parameters
+     */
+    private function command(array $parameters): string
+    {
+        if (count($parameters) === 1 && strpos($parameters[0], '^') === 0) {
+            return $parameters[0];
+        }
+
+        $command = ltrim(strtoupper(array_shift($parameters)), '^');
+        $parameters = array_map(function ($parameter) {
+            return !is_bool($parameter) ? $parameter : ($parameter ? 'Y' : 'N');
+        }, $parameters);
+
+        return '^' . $command . implode(',', $parameters);
+    }
+
+    /**
      * Adds an arbitrary command to the command queue
      *
      * @param string $command
      */
     public function addCommand(string $command) : void
     {
-        $this->commands[] = $command;
+        $this->commands[] = $this->command(func_get_args());
     }
 
     /**
@@ -264,7 +282,7 @@ class ZplBuilder extends AbstractBuilder
      */
     public function addPreCommand(string $command) : void
     {
-        $this->preCommands[] = $command;
+        $this->preCommands[] = $this->command(func_get_args());
     }
     
     /**
@@ -273,7 +291,9 @@ class ZplBuilder extends AbstractBuilder
      */
     public function setPreCommands(array $commands) : void
     {
-        $this->preCommands = $commands;
+        $this->preCommands = array_map(function ($command) {
+            return array_map([$this, 'command'], is_array($command) ? $command : [$command]);
+        }, $commands);
     }
     
     /**
@@ -282,7 +302,7 @@ class ZplBuilder extends AbstractBuilder
      */
     public function addPostCommand(string $command) : void
     {
-        $this->postCommands[] = $command;
+        $this->postCommands[] = $this->command(func_get_args());
     }
     
     /**
@@ -291,9 +311,25 @@ class ZplBuilder extends AbstractBuilder
      */
     public function setPostCommands(array $commands) : void
     {
-        $this->postCommands = $commands;
+        $this->postCommands = array_map(function ($command) {
+            return array_map([$this, 'command'], is_array($command) ? $command : [$command]);
+        }, $commands);
     }
     
+    /**
+     * Handle dynamic method calls.
+     *
+     * @param string $method
+     * @param array $arguments
+     * @return void
+     */
+    public function __call($method, $arguments)
+    {
+        array_unshift($arguments, $method);
+
+        $this->commands[] = call_user_func_array([$this, 'command'], [$arguments]);
+    }
+
     /**
      * Adds a new label
      *

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -259,6 +259,10 @@ class ZplBuilder extends AbstractBuilder
         }
 
         $command = ltrim(strtoupper(array_shift($parameters)), '^');
+        if ($command === 'GF' && count($parameters) === 1)  {
+            $gf = new GraphicField();
+            return $gf->createCommand($parameters[0], 0);
+        }
         $parameters = array_map(function ($parameter) {
             return !is_bool($parameter) ? $parameter : ($parameter ? 'Y' : 'N');
         }, $parameters);
@@ -326,8 +330,7 @@ class ZplBuilder extends AbstractBuilder
     public function __call($method, $arguments)
     {
         array_unshift($arguments, $method);
-
-        $this->commands[] = call_user_func_array([$this, 'command'], [$arguments]);
+        $this->commands[] = $this->command($arguments);
     }
 
     /**


### PR DESCRIPTION
This update improves the `addCommand` method to accept both string-based and structured command syntax.
This makes the API clearer, and more flexible when building dynamic ZPL commands.

```php
// BEFORE
$driver->addCommand('^FO40,40^GC40,4,B^FS');
// AFTER 
$driver->addCommand('FO', 40, 40); // if you write '^FO' it works too
$driver->addCommand('GC', 40, 4, 'B');
$driver->addCommand('FS');
// OR JUST CALL COMMAND DIRECTLY
$driver->fo(40, 40);
$driver->gc(40, 4, 'B');
$driver->fs();
```
**GF Example**
```php
// BEFORE
$driver->addCommand('^FO10,10^GFA,12,12,2,,:G0G4,,G9GB,,^FS');
// AFTER 
$driver->addCommand('FO', 10, 10);
$driver->addCommand('GF', 'A', 12, 12, 2, ',:G0G4,,G9GB,,');
$driver->addCommand('FS');
//Or
$driver->fo(10, 10);
$driver->gf('image.png'); // You can also send the file as the only argument
$driver->fs();
```