### PR TITLE
Make ^ ~ characters printable by using hex

### DIFF
--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -206,9 +206,9 @@ class ZplBuilder extends AbstractBuilder
             $offsetY = $this->toDots($height) / 4;
             $this->commands[] = '^FO' . ($this->toDots($x) + $offsetX) . ',' . ($this->toDots($y) + $offsetY);
             if ($align !== '') {
-                $this->commands[] = '^FB' . ($this->toDots($width) - $offsetX) . ',' . ($this->toDots($height) - $offsetY) . ',0,' . $align;
+                $this->commands[] = '^FB' . round($this->toDots($width) - $offsetX) . ',' . round($this->toDots($height) - $offsetY) . ',0,' . $align;
             }
-            $this->commands[] = '^FD' . $text . '^FS';
+            $this->commands[] = '^FH^FD' . strtr($text, self::CONTROL_CHAR_HEX_MAPPINGS) . '^FS';
         }
         if ($ln === true) {
             $this->setY($y + $height) ;

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -40,6 +40,18 @@ class ZplBuilder extends AbstractBuilder
     protected $fontMapper;
     
     const PAGE_SEPARATOR = '%PAGE_SEPARATOR%';
+
+    const CONTROL_CHAR_HEX_MAPPINGS = [
+        '_' => '_5F',
+        '^' => '_5E',
+        '~' => '_7E',
+        '{' => '_7B',
+        '}' => '_7D',
+        '[' => '_5B',
+        ']' => '_5D',
+        '#' => '_23',
+        '%' => '_25',
+    ];
     
     /**
      *
@@ -99,7 +111,7 @@ class ZplBuilder extends AbstractBuilder
         if ($invert === true) {
             $this->commands[] = '^FR';
         }
-        $this->commands[] = '^FD' . $text . '^FS';
+        $this->commands[] = '^FH^FD' . strtr($text, self::CONTROL_CHAR_HEX_MAPPINGS) . '^FS';
         $this->commands[] = '^FWN';
     }
     


### PR DESCRIPTION
`^FB` does not support decimals
`^FB: Value '389.6062992126' is not a valid number; suffix '.6062992126' was ignored`

```php
$driver->SetXY(10, 10);
$driver->drawCell(50, 50, 'Hello ^~_ World');
$driver->drawText(10, 50, 'Hello ^~_ World');
```