### PR TITLE
Fix `setFont` signature

### DIFF
--- a/src/AbstractBuilder.php
+++ b/src/AbstractBuilder.php
@@ -54,8 +54,9 @@ abstract class AbstractBuilder
      *
      * @param string $font The font number on the printer
      * @param float  $size The font's size in pt
+     * @param float|null  $width The font's width in pt
      */
-    abstract public function setFont(string $font, float $size) : void;
+    abstract public function setFont(string $font, float $size, ?float $width = null) : void;
     
     /**
      * Insert a text into the document.

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -30,7 +30,7 @@ class PdfBuilder extends AbstractBuilder
      * {@inheritDoc}
      * @see \Zpl\AbstractBuilder::setFont()
      */
-    public function setFont(string $font, float $size) : void
+    public function setFont(string $font, float $size, ?float $width = null) : void
     {
         $this->pdfDriver->SetFont($font, '', $size);
     }


### PR DESCRIPTION
`?float $width = null` is missing
https://github.com/andersonls/zpl/blob/82905a87587d14d30ba71970e9acea4b628f5814/src/ZplBuilder.php#L60-L62

**UPDATE:** merged with master and pint applied 