### PR TITLE
Add print quantity, serial number support

### DIFF
--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -88,9 +88,9 @@ class ZplBuilder extends AbstractBuilder
         $this->commands[] = $command;
     }
 
-    public function setQuantity(int $quantity, int $pauseQty = 0, int $replicate = 1): void
+    public function setQuantity(int $quantity, int $pauseQty = 0, int $replicate = 0): void
     {
-        $this->commands[] = '^PQ' . $quantity . ',' . $pauseQty . ',' . ($replicate <= 0 ? 1 : $replicate);
+        $this->commands[] = '^PQ' . $quantity . ',' . $pauseQty . ',' . ($replicate < 0 ? 0 : $replicate);
     }
 
     /**

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -76,6 +76,32 @@ class ZplBuilder extends AbstractBuilder
         
         $this->commands[] = $command;
     }
+
+    /**
+     * @param int $quantity
+     * @param int $pauseQty
+     * @param int $replicate
+     */
+    public function setQuantity(int $quantity, int $pauseQty = 0, int $replicate = 1): void
+    {
+        $this->commands[] = '^PQ' . $quantity . ',' . $pauseQty . ',' . ($replicate <= 0 ? 1 : $replicate);
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     * @see \Zpl\AbstractBuilder::drawText()
+     */
+    public function drawSerialNumber(float $x, float $y, string $text, string $orientation = 'N', bool $invert = false, int $step = 1, bool $ceroFill = true) : void
+    {
+        $this->commands[] = '^FW' . $orientation;
+        $this->commands[] = '^FO' . $this->toDots($x) . ',' . $this->toDots($y);
+        if ($invert === true) {
+            $this->commands[] = '^FR';
+        }
+        $this->commands[] = '^SN' . $text . ',' . ($step <= 0 ? 1 : $step) . ',' . ($ceroFill === true ? 'Y' : 'N'). '^FS';
+        $this->commands[] = '^FWN';
+    }
     
     /**
      * Value from 0 to 36.

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -94,11 +94,16 @@ class ZplBuilder extends AbstractBuilder
     }
 
     /**
-     * {@inheritDoc}
+     * Insert a autoincrement serial number into the document.
      *
-     * @see \Zpl\AbstractBuilder::drawText()
+     * @param float $x X position in user units
+     * @param float $y Y position in user units
+     * @param string $start starting number, interpreted as an integer, and may have leading zeros(0001)
+     * @param int $step the increment value for the serial number
+     * @param bool $pad to ensure a fixed length padded with zeros based on $start arg format
+     * @param bool $invert Invert the color based on the background behind the text
      */
-    public function drawSerialNumber(float $x, float $y, int $start = 1, int $step = 1, bool $pad = true, bool $invert = false): void
+    public function drawSerialNumber(float $x, float $y, string $start = '1', int $step = 1, bool $pad = true, bool $invert = false): void
     {
         $this->commands[] = '^FO' . $this->toDots($x) . ',' . $this->toDots($y);
         if ($invert === true) {

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -98,15 +98,13 @@ class ZplBuilder extends AbstractBuilder
      *
      * @see \Zpl\AbstractBuilder::drawText()
      */
-    public function drawSerialNumber(float $x, float $y, string $text, string $orientation = 'N', bool $invert = false, int $step = 1, bool $ceroFill = true): void
+    public function drawSerialNumber(float $x, float $y, int $start = 1, int $step = 1, bool $pad = true, bool $invert = false): void
     {
-        $this->commands[] = '^FW' . $orientation;
         $this->commands[] = '^FO' . $this->toDots($x) . ',' . $this->toDots($y);
         if ($invert === true) {
             $this->commands[] = '^FR';
         }
-        $this->commands[] = '^SN' . $text . ',' . ($step <= 0 ? 1 : $step) . ',' . ($ceroFill === true ? 'Y' : 'N') . '^FS';
-        $this->commands[] = '^FWN';
+        $this->commands[] = '^SN' . $start . ',' . ($step <= 0 ? 1 : $step) . ',' . ($pad ? 'Y' : 'N') . '^FS';
     }
 
     /**


### PR DESCRIPTION
```php
// `^SN` command, it auto-increments number(needs ``setQuantity`), like 0001, 0002, .....n
$driver->drawSerialNumber(0, 20, '00001'); //from 00001 to 00010
// labels to print, the third argument is the duplicates per label
// with `^SN` 2 labels, 2 duplicates result(2 x 2 = 4 labels): 001, 001, 002, 002
$driver->setQuantity(10); // Quantity, PauseQuantity, Duplicates number
```