### PR TITLE
Use Generic font mapper as default

### DIFF
--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -51,6 +51,7 @@ class ZplBuilder extends AbstractBuilder
     public function __construct(string $unit = 'dots', int $resolution = 203)
     {
         parent::__construct($unit);
+        $this->fontMapper = new Fonts\Generic();
         $this->resolution = $resolution;
     }
     


### PR DESCRIPTION
I think it should have a default that should be replaced by the specific one (if one exists).
less user code