### PR TITLE
Resolution Getter/Setter for Dpi and Dpmm

### DIFF
--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -342,6 +342,26 @@ class ZplBuilder extends AbstractBuilder
         }
         return round($sizeInDots, 2);
     }
+
+    public function setDpi(int $resolution) : void
+    {
+        $this->resolution = $resolution;
+    }
+
+    public function getDpi() : int
+    {
+        return $this->resolution;
+    }
+
+    public function setDpmm(int $resolution) : void
+    {
+        $this->resolution = round($resolution * 25.4);
+    }
+
+    public function getDpmm() : int
+    {
+        return round($this->resolution / 25.4);
+    }
     
     public function setFontMapper(Fonts\AbstractMapper $mapper) : void
     {


### PR DESCRIPTION
<img width="335" height="180" alt="image" src="https://github.com/user-attachments/assets/c05b1b15-ef2a-42b7-969e-5b72f97bf2c3" />

I'm using https://labelary.com/service.html#parameters for preview, it needs dpmm resolution, I receive the object for the preview, and it might have a different resolution, which is not accessible.