### PR TITLE
Macros support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ $driver->CF('A', 30); // ^CFA,30  (be careful with arguments and expected format
 \Zpl\Printer::printer('192.168.1.100')->send($driver->toZpl());
 ```
 
+## Macros
+
+You can extend the ZplBuilder with custom macros to add reusable commands or behaviors. Macros are registered using the `macro()` method and can be called as if they were native methods.
+
+### Registering a Macro
+
+```php
+$builder = new \Zpl\ZplBuilder('mm');
+\Zpl\ZplBuilder::macro('drawCustomBox', function($x, $y, $w, $h) {
+    $this->drawRect($x, $y, $w, $h);
+    $this->drawText($x + 2, $y + 2, 'Custom');
+});
+```
+
+### Using a Macro
+
+```php
+$builder->drawCustomBox(10, 10, 50, 20);
+```
+
+### Notes
+- Macros have access to the builder instance via `$this`.
+- You can override existing methods, but use caution to avoid breaking core functionality.
+- Macros are useful for encapsulating label patterns, custom shapes, or repetitive tasks.
+
 Notes and tips
 
 - Units: the constructor accepts the unit string (for example: `mm` or `dots`). When using `mm`, coordinates are converted to printer dots using the configured DPI (default 203).

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -38,6 +38,13 @@ class ZplBuilder extends AbstractBuilder
      * @var Fonts\AbstractMapper
      */
     protected $fontMapper;
+
+    /**
+     * The registered string macros.
+     *
+     * @var array
+     */
+    protected static $macros = [];
     
     const PAGE_SEPARATOR = '%PAGE_SEPARATOR%';
 
@@ -342,8 +349,15 @@ class ZplBuilder extends AbstractBuilder
      */
     public function __call($method, $arguments)
     {
+        if ($macro = (static::$macros[$method] ?? false)) {
+            $macro = $macro->bindTo($this);
+            return $macro(...$arguments);
+        }
+
         array_unshift($arguments, $method);
         $this->commands[] = $this->command($arguments);
+
+        return $this;
     }
 
     /**
@@ -423,5 +437,20 @@ class ZplBuilder extends AbstractBuilder
         $this->commands = [];
         $this->preCommands = [];
         $this->postCommands = [];
+    }
+
+    /**
+     * Register a custom macro.
+     *
+     * @param  string  $name
+     * @param  callable  $macro
+     *
+     * @param-closure-this static  $macro
+     *
+     * @return void
+     */
+    public static function macro($name, $macro)
+    {
+        static::$macros[$name] = $macro;
     }
 }

--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -321,14 +321,18 @@ class ZplBuilder extends AbstractBuilder
      *
      * @param string $method
      * @param array $arguments
-     * @return void
+     * @return mixed
      */
-    public function __call($method, $arguments)
+    public function __call(string $method, array $arguments)
     {
         if ($macro = (static::$macros[$method] ?? false)) {
             $macro = $macro->bindTo($this);
 
             return $macro(...$arguments);
+        }
+
+        if (method_exists($this, $method)) {
+            return call_user_func_array([$this, $method], $arguments);
         }
 
         array_unshift($arguments, $method);


### PR DESCRIPTION
This would allow us to create our own custom commands (a group of commands in each macro), and if any command is missing, it's easy to add it.
```php
// on app boot or loader
\Zpl\ZplBuilder::macro('macroDemo', function ($x, $y, $c){
    $this->fo($x,$y);
    $this->gc($x,$c,'B')
    $this->fs();
});
\Zpl\ZplBuilder::macro('drawDot', function (float $x, float $y) {
    $this->commands[] = '^FO' . $this->toDots($x) . ',' . $this->toDots($y) . '^GB2^FS';
    return $this:
});

// then like a native method
$driver->drawDot(5, 5)
       ->drawDot(5, 100);
       ->drawDot(100, 5)
       ->drawDot(100, 100)
       ->macroDemo(40, 40, 4);
```