### PR TITLE
Only suggest ext-sockets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,16 @@
   "license": "GPL-3.0-or-later",
   "homepage": "https://github.com/andersonls/zpl",
   "require": {
-    "php": ">=7.2",
-    "ext-sockets": "*"
+    "php": ">=7.2"
   },
   "require-dev": {
     "ext-gd": "*",
+    "ext-sockets": "*",
     "laravel/pint": "^1.0"
   },
   "suggest": {
-    "ext-gd": "*"
+    "ext-gd": "*",
+    "ext-sockets": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
https://github.com/andersonls/zpl/blob/dd8cda87691bdd2048967cf98e806dfcd4162c54/composer.json#L9-L11

Currently I'm only using the ZPL generator; I don't need the Printer class, as I already have another service handling that.
With this change, I get the following:
```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires PHP extension ext-sockets *
      but it is missing from your system. Install or enable PHP's sockets extension.

To enable extensions, verify that they are enabled in your .ini files
```
Is it possible to leave it as just a suggestion _(like ext-gd)_?

https://github.com/andersonls/zpl/blob/dd8cda87691bdd2048967cf98e806dfcd4162c54/composer.json#L17-L19