### PR TITLE
Support custom unit on image width

### DIFF
--- a/src/ZplBuilder.php
+++ b/src/ZplBuilder.php
@@ -317,7 +317,7 @@ class ZplBuilder extends AbstractBuilder
         $gf = new GraphicField();
 
         $this->commands[] = '^FO' . $this->toDots($x) . ',' . $this->toDots($y);
-        $this->commands[] = $gf->createCommand($image, $width);
+        $this->commands[] = $gf->createCommand($image, $this->toDots($width));
         $this->commands[] = '^FS';
     }
 


### PR DESCRIPTION
Is there a reason why the width is used directly in this part instead of transforming it from the custom unit?