### PR TITLE
Fix imagedestroy deprecation

### DIFF
--- a/src/Commands/GraphicField.php
+++ b/src/Commands/GraphicField.php
@@ -49,7 +49,6 @@ class GraphicField
         $white = imagecolorallocate($resized, 255, 255, 255);
         imagefilledrectangle($resized, 0, 0, $width, $height, $white); /* @phpstan-ignore argument.type */
         imagecopyresampled($resized, $im, 0, 0, 0, 0, $width, $height, $originalWidth, $originalHeight);
-        imagedestroy($im);
 
         $im = $resized;
 
@@ -87,7 +86,6 @@ class GraphicField
             $graphic[] = $compressData === true ? $this->compressRow($row, $lastRow) : $row;
             $lastRow = $row;
         }
-        imagedestroy($im);
 
         return '^GFA,' . $total . ',' . $total . ',' . $widthBytes . ',' . implode('', $graphic);
     }


### PR DESCRIPTION
https://www.php.net/manual/en/function.imagedestroy.php
> **Warning** This function has been _DEPRECATED_ as of PHP 8.5.0. Relying on this function is highly discouraged.
>
> **Note:** This function has no effect. Prior to PHP 8.0.0