### PR TITLE
Avoid docs directory on vendor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 /.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
+/docs               export-ignore
 /tests              export-ignore
 /pint.json          export-ignore
 /phpstan*           export-ignore


### PR DESCRIPTION
Markdown is not easy to read from flat files, references are lost,
and usually nobody looks for the docs on the vendor